### PR TITLE
🔧 Fixed the path to funding.yml

### DIFF
--- a/funding.yml
+++ b/funding.yml
@@ -1,0 +1,1 @@
+github: [rishighan]


### PR DESCRIPTION
This PR fixes the path for `funding.yml`, it was earlier incorrectly positioned inside `src/`